### PR TITLE
A minimal metamodel HOW requires archetypes method

### DIFF
--- a/t/01-kind.t
+++ b/t/01-kind.t
@@ -17,6 +17,8 @@ subtest 'instantiation', {
 
 subtest 'naming', {
     my class MinimalHOW {
+        my $archetypes = Metamodel::Archetypes.new(:nominal);
+        method archetypes { $archetypes }
         method new_type(MinimalHOW:_: --> Mu) {
             my MinimalHOW:D $meta := self.new;
             Metamodel::Primitives.create_type: $meta, 'Uninstantiable';
@@ -24,6 +26,8 @@ subtest 'naming', {
     }
 
     my class MinimalNamedHOW does Metamodel::Naming {
+        my $archetypes = Metamodel::Archetypes.new(:nominal);
+        method archetypes { $archetypes }
         method new_type(MinimalNamedHOW:_: Str:D :$name! --> Mu) {
             my MinimalNamedHOW:D $meta := self.new;
             my Mu                $type := Metamodel::Primitives.create_type: $meta, 'Uninstantiable';


### PR DESCRIPTION
A type object must be classified.

The problem revealed itself when tested against rakudo/rakudo#4096